### PR TITLE
add group without prefix;change verify method;

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,32 @@
 {
-    "name": "weboap/option",
-    "description": "Save and retreive config from db for laravel 4 / Access Config as Array",
-    "keywords": ["framework", "laravel 4","Option", "configuration"],
-    "license": "BSD-2-Clause",
-    "authors": [
-        {
-            "name": "weboap",
-            "email": "weboap@gmail.com"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.0"
+	"name": "weboap/option",
+	"description": "Save and retreive config from db for laravel 4 / Access Config as Array",
+	"keywords": ["framework", "laravel 4", "Option", "configuration"],
+	"license": "BSD-2-Clause",
+	"authors": [
+		{
+			"name": "weboap",
+			"email": "weboap@gmail.com"
+		}
+	],
+	"require": {
+		"php": ">=5.3.0"
 
-    },
-    "autoload": {
-        "classmap": [
-            "src/migrations",
-	    "tests"
-        ],
-        "psr-0": {
-            "Weboap\\Option": "src/"
-        }
-    },
+	},
+	"autoload": {
+		"classmap": [
+			"src/migrations",
+			"tests"
+		],
+		"psr-0": {
+			"Weboap\\Option": "src/"
+		}
+	},
 	"minimum-stability": "stable",
 	"require-dev": {
-               "illuminate/support": "4.1.x",
-                "mockery/mockery": "dev-master",
+		"illuminate/support": "4.1.x",
+		"mockery/mockery": "dev-master",
 		"way/laravel-test-helpers": "dev-master"
-		
-		}
+
+	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,12 +9,12 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
->
+        >
     <testsuites>
         <testsuite name="Unit">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
-       
-        
+
+
     </testsuites>
 </phpunit>

--- a/src/Weboap/Option/Exceptions/InvalidArgumentException.php
+++ b/src/Weboap/Option/Exceptions/InvalidArgumentException.php
@@ -1,7 +1,8 @@
 <?php namespace Weboap\Option\Exceptions;
 
-
 use Illuminate\Exception\Handler as Exception;
 
+class InvalidArgumentException extends Exception
+{
 
-class InvalidArgumentException extends Exception {}
+}

--- a/src/Weboap/Option/Exceptions/SaveException.php
+++ b/src/Weboap/Option/Exceptions/SaveException.php
@@ -1,7 +1,8 @@
 <?php namespace Weboap\Option\Exceptions;
 
-
 use Illuminate\Exception\Handler as Exception;
 
+class SaveException extends Exception
+{
 
-class SaveException extends Exception {}
+}

--- a/src/Weboap/Option/Facades/Option.php
+++ b/src/Weboap/Option/Facades/Option.php
@@ -2,13 +2,16 @@
 
 use Illuminate\Support\Facades\Facade;
 
-class Option extends Facade {
+class Option extends Facade
+{
 
     /**
      * Get the registered name of the component.
      *
      * @return string
      */
-    protected static function getFacadeAccessor() { return 'option'; }
-
+    protected static function getFacadeAccessor()
+    {
+        return 'option';
+    }
 }

--- a/src/Weboap/Option/Interfaces/OptionClassInterface.php
+++ b/src/Weboap/Option/Interfaces/OptionClassInterface.php
@@ -1,19 +1,17 @@
 <?php namespace Weboap\Option\Interfaces;
 
+interface OptionClassInterface
+{
 
+    public function set($key, $value);
 
-interface OptionClassInterface {
-    
-   public function set($key, $value);
-   
-   public function batchSet(array $array);
-   
-   public function get($key);
-   
-   public function forget($key);
-   
-   public function has($key);
-   
-   public function all();
-    
+    public function batchSet(array $array);
+
+    public function get($key);
+
+    public function forget($key);
+
+    public function has($key);
+
+    public function all();
 }

--- a/src/Weboap/Option/Models/OptionModel.php
+++ b/src/Weboap/Option/Models/OptionModel.php
@@ -1,63 +1,41 @@
 <?php namespace Weboap\Option\Models;
 
-
-
 use Illuminate\Support\Facades\Config as Config;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
+class OptionModel extends Eloquent
+{
 
-class OptionModel extends Eloquent {
-    
-        protected $table = null;
-        
-        protected $fillable = array( 'key', 'val');
-      
-      
-      
-        public function __construct()
-        {
-                 $table =  Config::get('option::table', 'options');
-                 
-                 $this->setTable($table);
-                
+    protected $table = null;
+
+    protected $fillable = array('key', 'val');
+
+    public function __construct()
+    {
+        $table = Config::get('option::table', 'options');
+        $this->setTable($table);
+    }
+
+    public function setKeyAttribute($value)
+    {
+        $this->attributes['key'] = strtolower($value);
+    }
+
+    public function setValAttribute($value)
+    {
+        if (is_string($value)) {
+            $value = e($value);
         }
-        
-       
-        public function setKeyAttribute($value)
-	{
-		$r = explode(".", $value);
-		
-		if ( count($r) == 1 )
-		{
-			$value = 'global.'.$value;
-		}
-		
-		$this->attributes['key'] = strtolower( $value );
-	}
-	
-       
-        public function setValAttribute($value)
-	{
-		if(is_string($value ) )
-		{
-			$value = e($value);
-		}
-		
-		$this->attributes['val'] = serialize($value);
-	}
-        
-        public function getValAttribute($value)
-	{
-		return @unserialize( $value );
-	}
-	
-	public function getDates()
-	{
-		return array('created_at', 'updated_at');
-	}
-        
-    
-        
-    
-    
+        $this->attributes['val'] = serialize($value);
+    }
+
+    public function getValAttribute($value)
+    {
+        return @unserialize($value);
+    }
+
+    public function getDates()
+    {
+        return array('created_at', 'updated_at');
+    }
 }

--- a/src/Weboap/Option/Option.php
+++ b/src/Weboap/Option/Option.php
@@ -8,130 +8,122 @@ use Weboap\Option\Exceptions\InvalidArgumentException;
 use Weboap\Option\Interfaces\OptionClassInterface;
 use Weboap\Option\Storage\OptionInterface as OptionInterface;
 
+class Option implements ArrayAccess, Serializable, OptionClassInterface
+{
 
-
-
-class Option implements ArrayAccess, Serializable, OptionClassInterface{
-	
     /**
-    * The Config array
-    * @var array
-    */
+     * The Config array
+     *
+     * @var array
+     */
     protected $options = array();
 
     /**
-    * The Config array
-    * @var string
-    */	
+     * The Config array
+     *
+     * @var string
+     */
     protected $tableName = null;
 
     /**
-    * The Option Repository Interface Instance
-    * @var OpenInterface
-    */
+     * The Option Repository Interface Instance
+     *
+     * @var OpenInterface
+     */
     protected $storage;
 
     /**
-    * The Cache Manager Instance
-    * @var Cache
-    */
+     * The Cache Manager Instance
+     *
+     * @var Cache
+     */
     protected $cache;
 
     /**
-    * The Config Instance
-    * @var Config
-    */
+     * The Config Instance
+     *
+     * @var Config
+     */
     protected $setting;
 
     /**
-    * Initialize the Option Class
-    * build the Config array.
-    * @param OptionInterface $storage The Database Interface
-    * @param Cache $cache
-    */
-    public function __construct( OptionInterface $storage, Cache $cache, $cachekey = 'options' )
+     * Initialize the Option Class
+     * build the Config array.
+     *
+     * @param OptionInterface $storage The Database Interface
+     * @param Cache           $cache
+     */
+    public function __construct(OptionInterface $storage, Cache $cache, $cachekey = 'options')
     {
-            
-	    $this->storage = $storage;
-            $this->cache = $cache;
-
-            $this->cachekey = $cachekey;
-
-            $this->table = $this->storage->all();
-
-            // Set the config array like a typical config file is structured
-            $this->options = $this->table->lists('val', 'key');
+        $this->storage  = $storage;
+        $this->cache    = $cache;
+        $this->cachekey = $cachekey;
+        $this->table    = $this->storage->all();
+        // Set the config array like a typical config file is structured
+        $this->options = $this->table->lists('val', 'key');
     }
-    
 
     public function set($key, $val)
     {
         $this->offsetSet($key, $val);
     }
-    
 
-    public function batchSet( Array $array)
+    public function batchSet(Array $array)
     {
-            foreach($array as $key => $val)
-            {
-                    $this->offsetSet($key, $val);
-            }
+        foreach ($array as $key => $val) {
+            $this->offsetSet($key, $val);
+        }
     }
-    
-    
+
     public function offsetSet($key, $val)
     {
-
-            $key = $this->verify($key);
-	    
-		if($this->has($key)){
-	
-			    $this->storage->update($key,  $val);
-	
-			}
-			else
-			{
-			    $this->storage->create($key, $val );
-			       
-			}
-
-            $this->options[$key] = $val;
-
-            // Clear the database cache
-            $this->cache->forget( $this->cachekey );
+        $key = $this->verify($key);
+        if ($this->has($key)) {
+            $this->storage->update($key, $val);
+        } else {
+            $this->storage->create($key, $val);
+        }
+        $this->options[$key] = $val;
+        // Clear the database cache
+        $this->cache->forget($this->cachekey);
     }
 
-    
     /**
      * syntactic sugar for offsetGet($key)
      *
      */
     public function get($key)
     {
-	    return $this->offsetGet($key);
-    }
-    
-    public function getGroup($group)
-    {
-	$all = $this->all();
-	
-	foreach ($all as $key => $value)
-	{
-		if( ! starts_with( $key, $group.'.') )
-		{
-			unset($all[$key]);
-		}
-	}
-	
-	return count($all) > 0 ? $all : NULL;
+        return $this->offsetGet($key);
     }
 
+    public function getGroup($group, $withPrefix = true)
+    {
+        $all    = $this->all();
+        $prefix = $group . '.';
+        if ($withPrefix) {
+            foreach ($all as $key => $value) {
+                if (!starts_with($key, $prefix)) {
+                    unset($all[$key]);
+                }
+            }
+        } else {
+            $newAll = [];
+            foreach ($all as $key => $value) {
+                if (starts_with($key, $prefix)) {
+                    $newKey          = preg_replace("#^$prefix#", '', $key, 1);
+                    $newAll[$newKey] = $value;
+                }
+            }
+            $all = $newAll;
+        }
+        return count($all) > 0 ? $all : null;
+    }
 
     public function offsetGet($key)
     {
-            $key = $this->verify($key);
-		
-            return $this->offsetExists( $key ) ? $this->options[$key] : NULL;
+        $key = $this->verify($key);
+        return $this->offsetExists($key) ? $this->options[$key] : null;
     }
 
     /**
@@ -140,96 +132,93 @@ class Option implements ArrayAccess, Serializable, OptionClassInterface{
      */
     public function forget($key)
     {
-            $this->offsetUnset($key);
+        $this->offsetUnset($key);
     }
-    
 
     public function offsetUnset($key)
     {
-            $key = $this->verify($key);
-
-            //unset the key in array
-            unset($this->options[$key]);
-
-            //delete the key from db
-            $this->storage->delete($key);
-
-            // Clear the database cache
-            $this->cache->forget( $this->cachekey );
-    }	
+        $key = $this->verify($key);
+        //unset the key in array
+        unset($this->options[$key]);
+        //delete the key from db
+        $this->storage->delete($key);
+        // Clear the database cache
+        $this->cache->forget($this->cachekey);
+    }
 
     /**
      * syntactic sugar for offsetExists($key)
      *
      */
-
     public function has($key)
     {
-            return $this->offsetExists($key);
+        return $this->offsetExists($key);
     }
-
 
     public function offsetExists($key)
     {
-            $key = $this->verify($key);
-
-            return isset( $this->options[$key] );
+        $key = $this->verify($key);
+        return isset($this->options[$key]);
     }
 
     public function all()
     {
-            if( count( $this->options ) == 0 )
-            {
-                return null;
-            }    
-	    
-            return $this->options;
-
+        if (count($this->options) == 0) {
+            return null;
+        }
+        return $this->options;
     }
 
     public function clear()
     {
-
-            $this->storage->clear();
-            // Clear the database cache
-            $this->cache->forget( $this->cachekey );
-
+        $this->storage->clear();
+        // Clear the database cache
+        $this->cache->forget($this->cachekey);
     }
 
     public function serialize()
     {
-            return serialize($this->options);
+        return serialize($this->options);
     }
 
     public function unserialize($serialized)
     {
-            $config = unserialize($serialized);
-            foreach($config as $key => $val){
-                    $this[$key] = $val;
-            }
+        $config = unserialize($serialized);
+        foreach ($config as $key => $val) {
+            $this[$key] = $val;
+        }
     }
 
     public function toJson()
     {
-            return json_encode($this->options);
+        return json_encode($this->options);
     }
-
 
     private function verify($key = '')
     {
-            if( empty($key) || ! is_string( $key ))
-            {
-                    throw new InvalidArgumentException('Invalid Option Key!');
-            }
-
-            $key =  e( trim( $key ) );
-
-            return $key;	
+        if (empty($key) || !is_string($key)) {
+            throw new InvalidArgumentException('Invalid Option Key!');
+        }
+        $key = e(trim($key));
+        $key = strtolower($key);
+        $key = $this->toPrefix($key);
+        if (strlen($key) > 50) {
+            throw new InvalidArgumentException('Invalid Option Key Length, max=50!');
+        }
+        return $key;
     }
-    
-    
 
-
+    private function toPrefix($key)
+    {
+        $prefix = \Config::get('option::default_prefix');
+        if (empty($prefix)) {
+            throw new Exception('default_prefix can not be empty');
+        }
+        if (!str_is('*.*', $key)) {
+            $key = sprintf('%s.%s', $prefix, $key);
+        }
+        return $key;
+    }
 }
 
 

--- a/src/Weboap/Option/OptionServiceProvider.php
+++ b/src/Weboap/Option/OptionServiceProvider.php
@@ -2,97 +2,82 @@
 
 use Illuminate\Support\ServiceProvider;
 
-class OptionServiceProvider extends ServiceProvider {
+class OptionServiceProvider extends ServiceProvider
+{
 
-	/**
-	 * Indicates if loading of the provider is deferred.
-	 *
-	 * @var bool
-	 */
-	protected $defer = false;
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
 
-	/**
-	 * Bootstrap the application events.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		$this->package('weboap/option');
-		
-	}
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->package('weboap/option');
+    }
 
-	/**
-	 * Register the service provider.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		$this->RegisterStorage();
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->RegisterStorage();
+        $this->RegisterOption();
+        $this->RegisterBooting();
+    }
 
-		$this->RegisterOption();
-				
-		$this->RegisterBooting();
-	}
-	
-	
-	public function RegisterOption()
-	{
-		
-		$this->app['option'] = $this->app->share(function($app)
-			{
-			    $tableName = $this->app['config']->get('option::table', 'options');
-                            
-			    return new Option(
-					      $this->app->make('Weboap\Option\Storage\OptionEloquentRepository', array( $tableName) ),
-					        $app['cache'],
-						$tableName
-					      );
-			
-			});
-		
-		$this->app->bind('Weboap\Option\Option', function($app) {
-			
-			return $app['option'];
-		
-		    });
-		
-	}
-	
-	
-	
-	public function RegisterBooting()
-	{
-		
-		 $this->app->booting(function()
-				{
-				   $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-				   $loader->alias('Option', 'Weboap\Option\Facades\Option');
-			  
-				});
-		
-		
-	}
-	
-	
-	protected function RegisterStorage()
-	{
-		$this->app->singleton(
-			'Weboap\Option\Storage\OptionInterface',
-			'Weboap\Option\Storage\OptionEloquentRepository'
-                );
-	}
-	
+    public function RegisterOption()
+    {
+        $this->app['option'] = $this->app->share(
+            function ($app) {
+                $tableName = $this->app['config']->get('option::table', 'options');
+                return new Option($this->app->make(
+                    'Weboap\Option\Storage\OptionEloquentRepository',
+                    array($tableName)
+                ), $app['cache'], $tableName);
+            }
+        );
+        $this->app->bind(
+            'Weboap\Option\Option',
+            function ($app) {
+                return $app['option'];
+            }
+        );
+    }
 
-	/**
-	 * Get the services provided by the provider.
-	 *
-	 * @return array
-	 */
-	public function provides()
-	{
-		return array('option');
-	}
+    public function RegisterBooting()
+    {
+        $this->app->booting(
+            function () {
+                $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+                $loader->alias('Option', 'Weboap\Option\Facades\Option');
+            }
+        );
+    }
 
+    protected function RegisterStorage()
+    {
+        $this->app->singleton(
+            'Weboap\Option\Storage\OptionInterface',
+            'Weboap\Option\Storage\OptionEloquentRepository'
+        );
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return array('option');
+    }
 }

--- a/src/Weboap/Option/Seeds/DatabaseSeeder.php
+++ b/src/Weboap/Option/Seeds/DatabaseSeeder.php
@@ -3,24 +3,18 @@
 use \Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Seeder;
 
+class DatabaseSeeder extends Seeder
+{
 
-
-class DatabaseSeeder extends Seeder {
-
-	/**
-	 * Run the database seeds.
-	 *
-	 * @return void
-	 */
-	public function run()
-	{
-		Eloquent::unguard();
-
-		// $this->call('UserTableSeeder');
-
-		$this->call('Weboap\Option\Seeds\OptionsTableSeeder');
-		
-	}
-		
-
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Eloquent::unguard();
+        // $this->call('UserTableSeeder');
+        $this->call('Weboap\Option\Seeds\OptionsTableSeeder');
+    }
 }

--- a/src/Weboap/Option/Seeds/OptionsTableSeeder.php
+++ b/src/Weboap/Option/Seeds/OptionsTableSeeder.php
@@ -3,22 +3,18 @@
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use \Carbon\Carbon;
-
 use Option as o;
 
-class OptionsTableSeeder extends Seeder {
+class OptionsTableSeeder extends Seeder
+{
 
-	/**
-	 * Auto generated seed file
-	 *
-	 * @return void
-	 */
-	public function run()
-	{
-		
-		o::set('option.version','1.0.1');
-			
-		
-	}
-
+    /**
+     * Auto generated seed file
+     *
+     * @return void
+     */
+    public function run()
+    {
+        o::set('option.version', '1.0.1');
+    }
 }

--- a/src/Weboap/Option/Storage/OptionEloquentRepository.php
+++ b/src/Weboap/Option/Storage/OptionEloquentRepository.php
@@ -1,56 +1,44 @@
 <?php namespace Weboap\Option\Storage;
 
-
 use Weboap\Option\Models\OptionModel as o;
 
-
-class OptionEloquentRepository implements OptionInterface{
-
-
-protected $table;
-
-public function __construct( $table )
+class OptionEloquentRepository implements OptionInterface
 {
-    $this->table = $table;
-}
 
-public function all()
-{
-    // Query the database and cache it forever
-   return o::rememberForever( $this->table )->get();
-    
-}
-   
-public function update($key, $value)
-{
-    $array = array('key' => $key, 'val'=>$value );
-    
-    return o::whereKey( $key )->update($array);
-}    
-    
+    protected $table;
 
-public function create( $key, $value)
-{
-    $option = new o;
-    
-    $option->key = $key;
-    $option->val = $value;
-    
-    $option->save();
-    
-}
-    
-public function delete($key)
-{
-    return o::whereKey( $key )->delete();   
-    
-}
+    public function __construct($table)
+    {
+        $this->table = $table;
+    }
 
+    public function all()
+    {
+        // Query the database and cache it forever
+        return o::rememberForever($this->table)->get();
+    }
 
-public function clear()
-{
-     o::truncate();
-}
+    public function update($key, $value)
+    {
+        $array = array('key' => $key, 'val' => $value);
+        return o::whereKey($key)->update($array);
+    }
 
+    public function create($key, $value)
+    {
+        $option      = new o;
+        $option->key = $key;
+        $option->val = $value;
+        $option->save();
+    }
 
+    public function delete($key)
+    {
+        return o::whereKey($key)->delete();
+    }
+
+    public function clear()
+    {
+        o::truncate();
+    }
 }

--- a/src/Weboap/Option/Storage/OptionInterface.php
+++ b/src/Weboap/Option/Storage/OptionInterface.php
@@ -1,18 +1,15 @@
 <?php namespace Weboap\Option\Storage;
 
-
-
-interface OptionInterface {
+interface OptionInterface
+{
 
     public function all();
-    
-    public function update($key, $value );
-    
-    public function create( $key, $value );
-    
-    public function delete( $key );
-    
+
+    public function update($key, $value);
+
+    public function create($key, $value);
+
+    public function delete($key);
+
     public function clear();
-    
-    
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,10 +1,8 @@
-<?php  
+<?php
 
 return array(
-    
     //in case you decide to the change the table name
     //make sure to change it here also
-   'table'  => 'options' 
-    
-  
-  );
+    'table'          => 'options',
+    'default_prefix' => 'global',
+);

--- a/src/migrations/2013_09_18_034712_create_options_table.php
+++ b/src/migrations/2013_09_18_034712_create_options_table.php
@@ -1,38 +1,36 @@
-<?php 
-
-
+<?php
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateOptionsTable extends Migration {
+class CreateOptionsTable extends Migration
+{
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		
-		
-		Schema::create('options', function(Blueprint $table)
-		{
-			$table->increments('id')->unsigned();
-			$table->string('key', 50);
-			$table->text('val')->nullable();
-			$table->text('description')->nullable();
-			$table->timestamps();
-		});
-	}
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create(
+            'options',
+            function (Blueprint $table) {
+                $table->increments('id')->unsigned();
+                $table->string('key', 50)->unique();
+                $table->text('val')->nullable();
+                $table->text('description')->nullable();
+                $table->timestamps();
+            }
+        );
+    }
 
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-		Schema::drop('options');
-	}
-
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('options');
+    }
 }

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -1,133 +1,125 @@
-<?php 
-
+<?php
 use Mockery as m;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Cache\CacheManager as Cache;
 
-class OptionTest extends TestCase {
-
-use \Way\Tests\ModelHelpers;
-
-protected $op;
-protected $mock;
-
-
-
-public function setUp()
+class OptionTest extends TestCase
 {
-    parent::setUp();
-   
-   
-    
-    
-    $this->op = new \Weboap\Option\Option;
 
-    
-   
-}
+    use \Way\Tests\ModelHelpers;
 
-public function tearDown()
-{
-	m::close();
-}
+    protected $op;
 
-public function mock($class)
-{
-	$mock = m::mock($class);
-       
-	$this->app->instance($class, $mock);
-       
-	return $mock;
-}
+    protected $mock;
 
+    public function setUp()
+    {
+        parent::setUp();
+        $this->op = new \Weboap\Option\Option;
+    }
 
-/**
-* @expectedException InvalidArgumentException
-*/
-public function testSetInvalidArguments()
-{
-	$this->op->set([]);
-	$this->op->set(['' => 'bar']);
-	$this->op->set( [ 1 =>'bar' ]);
-	$this->op->set( [true =>'bar'] );
-	$this->op->set('1.2.3.4.5.6.7.8.', 'f');
-}
+    public function tearDown()
+    {
+        m::close();
+    }
 
+    public function mock($class)
+    {
+        $mock = m::mock($class);
+        $this->app->instance($class, $mock);
+        return $mock;
+    }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetInvalidArguments()
+    {
+        $this->op->set([]);
+        $this->op->set(['' => 'bar']);
+        $this->op->set([1 => 'bar']);
+        $this->op->set([true => 'bar']);
+        $this->op->set('1.2.3.4.5.6.7.8.', 'f');
+    }
 
-public function testSet()
-{
-	$this->op->set( ['foo' => 'bar']);
-	$this->op->set( ['foo1' => 'bar1']);
-	
-	$this->assertTrue( $this->op->has('foo'));
-	$this->assertEquals( 'bar', $this->op->get('foo'));
-	$this->assertEquals( 'bar1', $this->op->get('foo1'));
-	
-	$this->op->set( ['option1'=> 'value1', 'option2' => 'value2']);
-	$this->assertTrue( $this->op->has('option1'));
-	
-	
-}
+    public function testSet()
+    {
+        $this->op->set(['foo' => 'bar']);
+        $this->op->set(['foo1' => 'bar1']);
+        $this->assertTrue($this->op->has('foo'));
+        $this->assertEquals('bar', $this->op->get('foo'));
+        $this->assertEquals('bar1', $this->op->get('foo1'));
+        $this->op->set(['option1' => 'value1', 'option2' => 'value2']);
+        $this->assertTrue($this->op->has('option1'));
+    }
 
+    public function testForget()
+    {
+        $this->op->set(['foo' => 'bar']);
+        $this->op->forget('foo');
+        $this->assertFalse($this->op->has('foo'));
+        $this->op->set(['option1' => 'value1', 'option2' => 'value2']);
+        $this->op->forget('option1');
+        $this->assertTrue($this->op->has('option2'));
+    }
 
-public function testForget()
-{
-	$this->op->set( ['foo' => 'bar']);
-	$this->op->forget( 'foo' );
-	$this->assertFalse( $this->op->has('foo'));
-	
-	$this->op->set( ['option1'=> 'value1', 'option2' => 'value2']);
-	$this->op->forget( 'option1' );
-	$this->assertTrue( $this->op->has('option2'));
-	
-}
+    public function testUnicode()
+    {
+        $this->op->set(['a' => 'Hï¿½lfte']);
+        $this->op->set(['b' => 'Hï¿½fe']);
+        $this->op->set(['c' => 'Hï¿½fte']);
+        $this->op->set(['d' => 'saï¿½']);
+        $this->assertEquals('Hï¿½lfte', $this->op->get('a'));
+        $this->assertEquals('Hï¿½fe', $this->op->get('b'));
+        $this->assertEquals('Hï¿½fte', $this->op->get('c'));
+        $this->assertEquals('saï¿½', $this->op->get('d'));
+    }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetInvalidArguments()
+    {
+        $this->op->get([]);
+        $this->op->get();
+        $this->op->get(1);
+        $this->op->get(['foo' => 'bar']);
+        $this->op->get('12.', 'f');
+    }
 
-public function testUnicode()
-{
-    $this->op->set(['a'=>'Hälfte']);
-    $this->op->set(['b'=>'Höfe']);
-    $this->op->set(['c' => 'Hüfte']);
-    $this->op->set(['d' => 'saß']);
-    $this->assertEquals('Hälfte', $this->op->get('a'));
-    $this->assertEquals('Höfe', $this->op->get('b'));
-    $this->assertEquals('Hüfte', $this->op->get('c'));
-    $this->assertEquals('saß', $this->op->get('d'));
-} 
- 
- 
-/**
-* @expectedException InvalidArgumentException
-*/
-public function testGetInvalidArguments()
-{
-	$this->op->get([]);
-	$this->op->get();
-	$this->op->get( 1 );
-	$this->op->get( ['foo' =>'bar'] );
-	$this->op->get('12.', 'f');
-} 
- 
+    public function testResult()
+    {
+        //$this->op['foo'] = 'bar1';
+        Option::shouldReceive('get')->once()->with('foo11')->andReturn('bar');
+        $option = Option::get('foo11');
+        $this->assertEquals('bar', $option);
+    }
 
-public function testResult()
-{
-	//$this->op['foo'] = 'bar1';
-	
-	Option::shouldReceive('get')
-		->once()
-		->with('foo11')
-		->andReturn('bar');
-		
-	$option = Option::get('foo11');
-	
-	$this->assertEquals('bar', $option);
-	
-	
-	
-}
+    public function testAutoPrefix()
+    {
+        Option::set('foo', 'test');
+        $value = Option::get('foo');
+        $this->assertEquals('test', $value);
+        ////
+        Option::set('loki.age', '24');
+        $value = Option::get('loki.age');
+        $this->assertEquals('24', $value);
+    }
 
-
-
-
+    public function testWithoutGroupPrefix()
+    {
+        ////
+        Option::set('admin.name', 'loki');
+        Option::set('admin.age', '24');
+        $value = Option::get('admin.name');
+        $this->assertEquals('loki', $value);
+        ////
+        $values = Option::getGroup('admin');
+        $this->assertEquals('loki', array_get($values, 'admin.name'));
+        $this->assertEquals('24', array_get($values, 'admin.age'));
+        ////
+        $values = Option::getGroup('admin', false);
+        $this->assertEquals('loki', array_get($values, 'name'));
+        $this->assertEquals('24', array_get($values, 'age'));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,36 +1,29 @@
-<?php 
+<?php
 
 
 
-class TestCase extends \Illuminate\Foundation\Testing\TestCase {
+class TestCase extends \Illuminate\Foundation\Testing\TestCase
+{
 
     use \Way\Tests\ModelHelpers;
-    
 
-    
-    
     public function setUp()
     {
-       parent::setUp();
-    
-       $this->prepareForTests();
+        parent::setUp();
+        $this->prepareForTests();
     }
-    
-	/**
+
+    /**
      * Creates the application.
      *
      * @return HttpKernelInterface
      */
     public function createApplication()
     {
-	$unitTesting = true;
-
-	$testEnvironment = 'testing';
-
-	return require __DIR__ . '/../../../../bootstrap/start.php';
-
+        $unitTesting     = true;
+        $testEnvironment = 'testing';
+        return require __DIR__ . '/../../../../bootstrap/start.php';
     }
-    
 
     /**
      * Migrates the database and set the mailer to 'pretend'.
@@ -39,25 +32,17 @@ class TestCase extends \Illuminate\Foundation\Testing\TestCase {
      */
     protected function prepareForTests()
     {
-       
-	Artisan::call('migrate', array('--bench' => 'weboap/option'));
-	Artisan::call('db:seed', array('--class' => 'Weboap\Option\Seeds\DatabaseSeeder'));
-	
-    
+        Artisan::call('migrate', array('--bench' => 'weboap/option'));
+        Artisan::call('db:seed', array('--class' => 'Weboap\Option\Seeds\DatabaseSeeder'));
     }
-    
-    
-	/**
-	 * A basic functional test example.
-	 *
-	 * @return void
-	 */
-	public function test_it_works()
-	{		
-		$this->assertTrue(true);
-	}
-	   
-    
 
-
+    /**
+     * A basic functional test example.
+     *
+     * @return void
+     */
+    public function test_it_works()
+    {
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
1.migrations

```
  $table->string('key', 50)->unique();
```

2.Option.php

```
private function verify($key = '')
    {
        if (empty($key) || !is_string($key)) {
            throw new InvalidArgumentException('Invalid Option Key!');
        }
        $key = e(trim($key));
        $key = strtolower($key);
        $key = $this->toPrefix($key);
        if (strlen($key) > 50) {
            throw new InvalidArgumentException('Invalid Option Key Length, max=50!');
        }
        return $key;
    }

    private function toPrefix($key)
    {
        $prefix = \Config::get('option::default_prefix');
        if (empty($prefix)) {
            throw new Exception('default_prefix can not be empty');
        }
        if (!str_is('*.*', $key)) {
            $key = sprintf('%s.%s', $prefix, $key);
        }
        return $key;
    }
```

3.groupWithoutPrefix

```
 public function getGroup($group, $withPrefix = true)
    {
        $all    = $this->all();
        $prefix = $group . '.';
        if ($withPrefix) {
            foreach ($all as $key => $value) {
                if (!starts_with($key, $prefix)) {
                    unset($all[$key]);
                }
            }
        } else {
            $newAll = [];
            foreach ($all as $key => $value) {
                if (starts_with($key, $prefix)) {
                    $newKey          = preg_replace("#^$prefix#", '', $key, 1);
                    $newAll[$newKey] = $value;
                }
            }
            $all = $newAll;
        }
        return count($all) > 0 ? $all : null;
    }
```
